### PR TITLE
Update pgsql client to have min size of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.0.7 - 3/1/23
+- Set PostgreSQL connection pool to have a default pool size minimum of 0
+
 ## v0.0.5 - 2/22/23
 - Support write queries to PostgreSQL and MySQL databases
 - Support different return formats when querying PostgreSQL, MySQL, and Redshift databases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nypl_py_utils"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
   { name="Aaron Friedman", email="aaronfriedman@nypl.org" },
 ]

--- a/src/nypl_py_utils/classes/postgresql_client.py
+++ b/src/nypl_py_utils/classes/postgresql_client.py
@@ -19,12 +19,11 @@ class PostgreSQLClient:
                           '{db_name}').format(user=user, password=password,
                                               host=host, port=port,
                                               db_name=db_name)
-        self.min_size = kwargs.get('min_size', 1)
-        self.max_size = kwargs.get('max_size', None)
+        self.min_size = kwargs.get('min_size', 0)
+        self.max_size = kwargs.get('max_size', 1)
         self.pool = ConnectionPool(
             self.conn_info, open=False,
-            min_size=kwargs.get('min_size', 1),
-            max_size=kwargs.get('max_size', None))
+            min_size=self.min_size, max_size=self.max_size)
 
     def connect(self):
         """
@@ -73,7 +72,6 @@ class PostgreSQLClient:
         """
         self.logger.info('Querying {} database'.format(self.db_name))
         self.logger.debug('Executing query {}'.format(query))
-        self.pool.check()
         with self.pool.connection() as conn:
             try:
                 conn.row_factory = row_factory

--- a/tests/test_postgresql_client.py
+++ b/tests/test_postgresql_client.py
@@ -1,6 +1,7 @@
 import pytest
 
 from nypl_py_utils import PostgreSQLClient, PostgreSQLClientError
+from psycopg import Error
 
 
 class TestPostgreSQLClient:
@@ -17,7 +18,7 @@ class TestPostgreSQLClient:
             'postgresql://test_user:test_password@test_host:test_port/' +
             'test_db_name')
         assert test_instance.pool._opened is False
-        assert test_instance.pool.min_size == 1
+        assert test_instance.pool.min_size == 0
         assert test_instance.pool.max_size == 1
 
     def test_init_with_kwargs(self):
@@ -35,7 +36,10 @@ class TestPostgreSQLClient:
         test_instance.connect()
         test_instance.pool.open.assert_called_once_with(wait=True, timeout=300)
 
-    def test_connect_with_exception(self):
+    def test_connect_with_exception(self, mocker):
+        mocker.patch('psycopg_pool.ConnectionPool.open',
+                     side_effect=Error())
+
         test_instance = PostgreSQLClient(
             'test_host', 'test_port', 'test_db_name', 'test_user',
             'test_password', timeout=1.0)


### PR DESCRIPTION
psycopg_pool automatically closes connections after they are idle for max_idle (which is 10 minutes by default). However, it does not do this for the first min_size connections, which stay open forever -- even after the database considers them unhealthy and will no longer serve them. Unfortunately, check() will "discard" these unhealthy connections and open new ones, but it won't actually close them, leading to connection leaks.

The solution for now is to set the pool min_size to 0 so that all idle connections will be automatically closed. Note that there are other possible solutions/behaviors and this decision is subject to change.