### PR TITLE
Fix Oauth2ApiClient token refresh, responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.0.9 - 3/16/23
+- Improve Oauth2ApiClient token refresh and method responses
+
 ## v0.0.8 - 3/3/23
 - Pass in all kwargs from PostgreSQLClient to ConnectionPool so that all ConnectionPool settings
 can be set from the wrapper

--- a/src/nypl_py_utils/__init__.py
+++ b/src/nypl_py_utils/__init__.py
@@ -2,7 +2,7 @@ from .classes.avro_encoder import AvroEncoder, AvroEncoderError  # noqa
 from .classes.kinesis_client import KinesisClient, KinesisClientError  # noqa
 from .classes.kms_client import KmsClient, KmsClientError # noqa
 from .classes.mysql_client import MySQLClient, MySQLClientError  # noqa
-from .classes.oauth2_api_client import Oauth2ApiClient  # noqa
+from .classes.oauth2_api_client import Oauth2ApiClient, Oauth2ApiClientError  # noqa
 from .classes.postgresql_client import PostgreSQLClient, PostgreSQLClientError  # noqa
 from .classes.redshift_client import RedshiftClient, RedshiftClientError  # noqa
 from .classes.s3_client import S3Client, S3ClientError  # noqa

--- a/src/nypl_py_utils/classes/oauth2_api_client.py
+++ b/src/nypl_py_utils/classes/oauth2_api_client.py
@@ -80,9 +80,6 @@ class Oauth2ApiClient:
 
             self._generate_access_token()
             return self._do_http_method(method, request_path, **kwargs)
-        except TimeoutError as e:
-            self.logger.error(f'TimeoutError encountered: {e}')
-            return {}
 
     def _create_oauth_client(self):
         """

--- a/tests/test_oauth2_api_client.py
+++ b/tests/test_oauth2_api_client.py
@@ -111,8 +111,8 @@ class TestOauth2ApiClient:
         with pytest.raises(HTTPError):
             test_instance._do_http_method('GET', 'foo')
 
-    def test_token_refresh_failure_raises_error(self, requests_mock,
-            test_instance, token_server_post):
+    def test_token_refresh_failure_raises_error(
+            self, requests_mock, test_instance, token_server_post):
         """
         Failure to fetch a token can raise a number of errors including:
          - requests.exceptions.HTTPError for invalid access_token

--- a/tests/test_oauth2_api_client.py
+++ b/tests/test_oauth2_api_client.py
@@ -1,32 +1,36 @@
 import os
+import time
 import json
 import pytest
 from requests_oauthlib import OAuth2Session
+from requests import HTTPError
 
 from nypl_py_utils import Oauth2ApiClient
-# from requests.exceptions import ConnectTimeout
 
 _TOKEN_RESPONSE = {
     'access_token': 'super-secret-token',
-    'expires_in': 3600,
+    'expires_in': 1,
     'token_type': 'Bearer',
     'scope': ['offline_access', 'openid', 'login:staff', 'admin'],
-    'id_token': 'super-secret-token',
-    'expires_at': 1677599823.3180869
+    'id_token': 'super-secret-token'
 }
 
 BASE_URL = 'https://example.com/api/v0.1'
+TOKEN_URL = 'https://oauth.example.com/oauth/token'
 
 
 class TestOauth2ApiClient:
 
     @pytest.fixture
-    def test_instance(self, requests_mock):
-        token_url = 'https://oauth.example.com/oauth/token'
-        requests_mock.post(token_url, text=json.dumps(_TOKEN_RESPONSE))
+    def token_server_post(self, requests_mock):
+        token_url = TOKEN_URL
+        token_response = dict(_TOKEN_RESPONSE)
+        return requests_mock.post(token_url, text=json.dumps(token_response))
 
+    @pytest.fixture
+    def test_instance(self, requests_mock):
         return Oauth2ApiClient(base_url=BASE_URL,
-                               token_url=token_url,
+                               token_url=TOKEN_URL,
                                client_id='clientid',
                                client_secret='clientsecret'
                                )
@@ -50,42 +54,59 @@ class TestOauth2ApiClient:
         for key, value in env.items():
             os.environ[key] = ''
 
-    def test_generate_access_token(self, test_instance):
+    def test_generate_access_token(self, test_instance, token_server_post):
+        test_instance._create_oauth_client()
         test_instance._generate_access_token()
-        assert test_instance.token['access_token']\
+        assert test_instance.oauth_client.token['access_token']\
             == _TOKEN_RESPONSE['access_token']
 
-    def test_create_oauth_client(self, test_instance):
+    def test_create_oauth_client(self, token_server_post, test_instance):
         test_instance._create_oauth_client()
         assert type(test_instance.oauth_client) is OAuth2Session
 
-    def test_do_http_method(self, requests_mock, test_instance):
+    def test_do_http_method(self, requests_mock, token_server_post,
+                            test_instance):
+        requests_mock.get(f'{BASE_URL}/foo', json={'foo': 'bar'})
+
         requests_mock.get(f'{BASE_URL}/foo', json={'foo': 'bar'})
         resp = test_instance._do_http_method('GET', 'foo')
-        assert resp == {'foo': 'bar'}
+        assert resp.status_code == 200
+        assert resp.json() == {'foo': 'bar'}
 
-    def test_token_expiration(self, requests_mock, test_instance):
+    def test_token_expiration(self, requests_mock, test_instance,
+                              token_server_post, mocker):
         api_get_mock = requests_mock.get(f'{BASE_URL}/foo',
                                          json={'foo': 'bar'})
 
-        # Perform first request to auto-authenticate:
-        resp = test_instance._do_http_method('GET', 'foo')
+        # Perform first request:
+        test_instance._do_http_method('GET', 'foo')
+        # Expect this first call triggered a single token server call:
+        assert len(token_server_post.request_history) == 1
+        # And the GET request used the supplied Bearer token:
         assert api_get_mock.request_history[0]._request\
             .headers['Authorization'] == 'Bearer super-secret-token'
 
-        # Emulate token expiration:
-        test_instance.token['expires_at'] = 0
+        # The token obtained above expires in 1s, so wait out expiration:
+        time.sleep(1.1)
 
-        token_post_mock = requests_mock.post(
-            test_instance.token_url,
-            text=json.dumps(_TOKEN_RESPONSE)
-        )
+        # Register new token response:
+        second_token_response = dict(_TOKEN_RESPONSE)
+        second_token_response['id_token'] = 'super-secret-second-token'
+        second_token_response['access_token'] = 'super-secret-second-token'
+        second_token_server_post = requests_mock\
+            .post(TOKEN_URL, text=json.dumps(second_token_response))
 
-        # Perform second request, which should detect token expiration and
-        # re-authenticate:
-        resp = test_instance._do_http_method('GET', 'foo')
-
-        assert token_post_mock.called is True
+        # Perform second request:
+        test_instance._do_http_method('GET', 'foo')
+        # Expect a call on the second token server:
+        assert len(second_token_server_post.request_history) == 1
+        # Expect the second GET request to carry the new Bearer token:
         assert api_get_mock.request_history[1]._request\
-            .headers['Authorization'] == 'Bearer super-secret-token'
-        assert resp == {'foo': 'bar'}
+            .headers['Authorization'] == 'Bearer super-secret-second-token'
+
+    def test_error_status_raises_error(self, requests_mock, test_instance,
+                                       token_server_post):
+        requests_mock.get(f'{BASE_URL}/foo', status_code=400)
+
+        with pytest.raises(HTTPError):
+            test_instance._do_http_method('GET', 'foo')


### PR DESCRIPTION
Fixes various things with Oauth2ApiClient:
 - Ensure token is refetched when it expires
 - HTTP functions should return the `requests` response object, not just the json
 - Raise errors based on status_code
 - Better test coverage