### PR TITLE
fix: Always return response from _do_http_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.1.4 3/14/24
+- Fix bug with oauth2 requests after token refresh
+
 ## v1.1.3 11/9/23
 - Finalize retry logic in Oauth2 Client
 
@@ -12,7 +15,7 @@
 > Host: ilsstaff.nypl.org
 > User-Agent: curl/7.64.1
 > Accept: */*
-> 
+>
 ```
 - Due to an accidental deployment, v1.1.0 and v1.1.1 were both released but are identical
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nypl_py_utils"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="Aaron Friedman", email="aaronfriedman@nypl.org" },
 ]

--- a/src/nypl_py_utils/classes/oauth2_api_client.py
+++ b/src/nypl_py_utils/classes/oauth2_api_client.py
@@ -117,7 +117,7 @@ Oauth2 Client using path: {request_path}. Retry #{retries}')
                     from None
 
             self._generate_access_token()
-            return self._do_http_method(method, request_path, **kwargs).json()
+            return self._do_http_method(method, request_path, **kwargs)
 
     def _create_oauth_client(self):
         """

--- a/tests/test_oauth2_api_client.py
+++ b/tests/test_oauth2_api_client.py
@@ -3,7 +3,7 @@ import time
 import json
 import pytest
 from requests_oauthlib import OAuth2Session
-from requests import HTTPError, JSONDecodeError
+from requests import HTTPError, JSONDecodeError, Response
 
 from nypl_py_utils.classes.oauth2_api_client import (Oauth2ApiClient,
                                                      Oauth2ApiClientError)
@@ -120,7 +120,10 @@ class TestOauth2ApiClient:
             .post(TOKEN_URL, text=json.dumps(second_token_response))
 
         # Perform second request:
-        test_instance._do_http_method('GET', 'foo')
+        response = test_instance._do_http_method('GET', 'foo')
+        # Ensure we still return a plain requests Response object
+        assert isinstance(response, Response)
+        assert response.json() == {"foo": "bar"}
         # Expect a call on the second token server:
         assert len(second_token_server_post.request_history) == 1
         # Expect the second GET request to carry the new Bearer token:


### PR DESCRIPTION
Noticed a bug where the *first* time we queried an API after a long time (in this case Sierra), we'd see a json decode error coming from the requests modules `response.json()`. Since we weren't calling it on our end, I dug through the trace a little and found that we call `.json()` in this library *only* when the token is expired and we do a refresh, which would explain the timing of the bug.

So simply, make sure to return the raw response object when we do a token refresh.

Here's an example stacktrace of the bug we are encountering:

File /ereadingserver/./app/main.py, line 186, in login 
File /ereadingserver/./app/auth/login.py, line 62, in log_in_with_card 
File /ereadingserver/./app/sierra.py, line 106, in patron_is_valid 
File /usr/local/lib/python3.10/site-packages/nypl_py_utils/classes/oauth2_api_client.py, line 63, in post 
File /usr/local/lib/python3.10/site-packages/nypl_py_utils/classes/oauth2_api_client.py, line 106, in _do_http_method 
File /usr/local/lib/python3.10/site-packages/requests/models.py, line 975, in json

I updated a quick test that would repro this!

https://jira.nypl.org/browse/PJR-788