### PR TITLE
DE-101 (Python Rewrite): Added retry functionality when fetching Avro schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
+## v1.2.1 7/25/24
+- Add retry for fetching Avro schemas
+
 ## v1.2.0 7/17/24
-- Generalized Avro functions and separated encoding/decoding behavior.
+- Generalized Avro functions and separated encoding/decoding behavior
 
 ## v1.1.6 7/12/24
 - Add put functionality to Oauth2 Client

--- a/src/nypl_py_utils/classes/avro_client.py
+++ b/src/nypl_py_utils/classes/avro_client.py
@@ -37,7 +37,7 @@ class AvroClient:
         try:
 
             response = self.session.get(url=platform_schema_url,
-                                        timeout=300)
+                                        timeout=60)
             response.raise_for_status()
         except Exception as e:
             self.logger.error(

--- a/src/nypl_py_utils/classes/avro_client.py
+++ b/src/nypl_py_utils/classes/avro_client.py
@@ -1,4 +1,3 @@
-import time
 import avro.schema
 import requests
 
@@ -7,7 +6,7 @@ from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
 from io import BytesIO
 from nypl_py_utils.functions.log_helper import create_log
 from requests.adapters import HTTPAdapter, Retry
-from requests.exceptions import JSONDecodeError, RequestException
+from requests.exceptions import JSONDecodeError
 
 
 class AvroClient:

--- a/src/nypl_py_utils/classes/avro_client.py
+++ b/src/nypl_py_utils/classes/avro_client.py
@@ -1,3 +1,4 @@
+import time
 import avro.schema
 import requests
 
@@ -16,8 +17,8 @@ class AvroClient:
     """
 
     def __init__(self, platform_schema_url):
-        self.logger = create_log("avro_encoder")
-        retry_policy = Retry(total=2, backoff_factor=4,
+        self.logger = create_log("avro_client")
+        retry_policy = Retry(total=3, backoff_factor=45,
                              status_forcelist=[500, 502, 503, 504],
                              allowed_methods=frozenset(['GET']))
         self.session = requests.Session()
@@ -38,7 +39,7 @@ class AvroClient:
             response = self.session.get(url=platform_schema_url,
                                         timeout=300)
             response.raise_for_status()
-        except RequestException as e:
+        except Exception as e:
             self.logger.error(
                 "Failed to retrieve schema from {url}: {error}".format(
                     url=platform_schema_url, error=e
@@ -48,7 +49,7 @@ class AvroClient:
                 "Failed to retrieve schema from {url}: {error}".format(
                     url=platform_schema_url, error=e
                 )
-            ) from None
+            )
 
         try:
             json_response = response.json()

--- a/tests/test_avro_client.py
+++ b/tests/test_avro_client.py
@@ -2,7 +2,7 @@ import json
 import pytest
 
 from nypl_py_utils.classes.avro_client import (
-    AvroClient, AvroClientError, AvroDecoder, AvroEncoder)
+    AvroClientError, AvroDecoder, AvroEncoder)
 from requests.exceptions import ConnectTimeout
 
 _TEST_SCHEMA = {'data': {'schema': json.dumps({

--- a/tests/test_avro_client.py
+++ b/tests/test_avro_client.py
@@ -2,6 +2,8 @@ import json
 import pytest
 from unittest.mock import patch
 
+import requests
+
 from nypl_py_utils.classes.avro_client import (
     AvroClient, AvroClientError, AvroDecoder, AvroEncoder)
 from requests import session
@@ -47,14 +49,6 @@ class TestAvroClient:
         requests_mock.get("https://test_schema_url", exc=ConnectTimeout)
         with pytest.raises(AvroClientError):
             AvroEncoder("https://test_schema_url")
-
-    def test_get_json_schema_success_on_retry(self, requests_mock):
-        requests_mock.get("https://test_schema_url",
-                          [{"exc": ConnectionError},
-                           {"text": str(_TEST_SCHEMA), "status_code": 200}])
-
-        test_avro_client = AvroClient("https://test_schema_url")
-        assert test_avro_client.get_json_schema == _TEST_SCHEMA["data"]["schema"]
 
     def test_bad_json_error(self, requests_mock):
         requests_mock.get(

--- a/tests/test_avro_client.py
+++ b/tests/test_avro_client.py
@@ -1,12 +1,8 @@
 import json
 import pytest
-from unittest.mock import patch
-
-import requests
 
 from nypl_py_utils.classes.avro_client import (
-    AvroClient, AvroClientError, AvroDecoder, AvroEncoder)
-from requests import session
+    AvroClientError, AvroDecoder, AvroEncoder)
 from requests.exceptions import ConnectTimeout
 
 _TEST_SCHEMA = {'data': {'schema': json.dumps({

--- a/tests/test_avro_client.py
+++ b/tests/test_avro_client.py
@@ -2,7 +2,7 @@ import json
 import pytest
 
 from nypl_py_utils.classes.avro_client import (
-    AvroClientError, AvroDecoder, AvroEncoder)
+    AvroClient, AvroClientError, AvroDecoder, AvroEncoder)
 from requests.exceptions import ConnectTimeout
 
 _TEST_SCHEMA = {'data': {'schema': json.dumps({
@@ -25,17 +25,17 @@ class TestAvroClient:
     @pytest.fixture
     def test_avro_encoder_instance(self, requests_mock):
         requests_mock.get(
-            'https://test_schema_url', text=json.dumps(_TEST_SCHEMA))
-        return AvroEncoder('https://test_schema_url')
+            "https://test_schema_url", text=json.dumps(_TEST_SCHEMA))
+        return AvroEncoder("https://test_schema_url")
 
     @pytest.fixture
     def test_avro_decoder_instance(self, requests_mock):
         requests_mock.get(
-            'https://test_schema_url', text=json.dumps(_TEST_SCHEMA))
-        return AvroDecoder('https://test_schema_url')
+            "https://test_schema_url", text=json.dumps(_TEST_SCHEMA))
+        return AvroDecoder("https://test_schema_url")
 
-    def test_get_json_schema(self, test_avro_encoder_instance,
-                             test_avro_decoder_instance):
+    def test_get_json_schema_success(self, test_avro_encoder_instance,
+                                     test_avro_decoder_instance):
         assert test_avro_encoder_instance.schema == _TEST_SCHEMA['data'][
             'schema']
         assert test_avro_decoder_instance.schema == _TEST_SCHEMA['data'][


### PR DESCRIPTION
As per our offline discussion. This will be useful whenever the platform API is temporarily down. The retry functionality is inspired by [location-hours-poller](https://github.com/NYPL/location-hours-pollers/blob/f937edabb8a04420cc47edafd5b41893fdea1d6b/lib/locations_api_client.py#L16) and [patron-info-poller](https://github.com/NYPL/patron-info-poller/blob/22dabd254b3cc0ce2624cc1bc2c506484fef73d0/lib/census_geocoder_api_client.py#L17).