### PR TITLE
DE-175: Create general cloudLibrary client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.5.0 11/4/24
+- Added cloudLibrary client
+
 ## v1.4.0 9/23/24
 - Added SFTP client
 

--- a/src/nypl_py_utils/classes/cloudlibrary_client.py
+++ b/src/nypl_py_utils/classes/cloudlibrary_client.py
@@ -1,0 +1,119 @@
+import base64
+import hashlib
+import hmac
+import requests
+
+from datetime import datetime, timedelta
+from nypl_py_utils.functions.log_helper import create_log
+from requests.adapters import HTTPAdapter, Retry
+
+_API_URL = "https://partner.yourcloudlibrary.com/cirrus/library"
+_VERSION = "3.0.2"
+
+
+class CloudLibraryClient:
+    """Client for interacting with CloudLibrary API v3.0.2"""
+
+    def __init__(self, library_id, account_id, account_key):
+        self.logger = create_log("cloudlibrary_client")
+        self.library_id = library_id
+        self.account_id = account_id
+        self.account_key = account_key
+        self.base_url = f"{_API_URL}/{self.library_id}"
+        self.setup_session()
+
+    def setup_session(self):
+        """Authenticate and set up HTTP session"""
+        retry_policy = Retry(total=3, backoff_factor=45,
+                             status_forcelist=[500, 502, 503, 504],
+                             allowed_methods=frozenset(["GET"]))
+        self.session = requests.Session()
+        self.session.mount("https://",
+                           HTTPAdapter(max_retries=retry_policy))
+
+    def get_library_events(self, start_date: str, end_date: str) -> requests.Response:
+        """
+        Retrieves all the events related to library-owned items within the 
+        optional timeframe. Pulls yesterday's events by default.
+        """
+        yesterday = datetime.now() - timedelta(1)
+        yesterday_formatted = datetime.strftime(yesterday, "%Y-%m-%d")
+        start_date = yesterday_formatted if start_date is None else start_date
+        end_date = yesterday_formatted if end_date is None else end_date
+
+        path = f"data/cloudevents?startdate{start_date}&enddate={end_date}"
+        response = self.request(path, "GET")
+        return response
+
+    def create_request_body_with_filter(self, request_type: str, item_id: str, patron_id: str) -> str:
+        """
+        Helper function to generate request body when performing item 
+        and/or patron-specific functions (ex. checking out a title). 
+        """
+        request_template = "<%(request_type)s><ItemId>%(item_id)s</ItemId><PatronId>%(patron_id)s</PatronId></%(request_type)s>"
+        return request_template % {
+            "request_type": request_type,
+            "item_id": item_id,
+            "patron_id": patron_id,
+        }
+
+    def request(self, path, body=None, method_type="GET") -> requests.Response:
+        headers = self._build_headers(method_type, path)
+        url = f"{self.base_url}/{path}"
+        method_type = method_type.upper()
+
+        try:
+            if method_type == "GET":
+                response = self.session.get(url=url,
+                                            data=body,
+                                            headers=headers,
+                                            timeout=60)
+            elif method_type == "PUT":
+                response = self.session.put(url=url,
+                                            data=body,
+                                            headers=headers,
+                                            timeout=60)
+            else:
+                response = self.session.post(url=url,
+                                             data=body,
+                                             headers=headers,
+                                             timeout=60)
+            response.raise_for_status()
+        except Exception as e:
+            error_message = f"Failed to retrieve response from {url}: {e}"
+            self.logger.error(error_message)
+            raise CloudLibraryClientError(error_message)
+
+        return response
+
+    def _build_headers(self, method_type: str, path: str) -> dict:
+        time, authorization = self._build_authorization(method_type, path)
+        headers = {
+            "3mcl-Datetime": time,
+            "3mcl-Authorization": authorization,
+            "3mcl-Version": _VERSION,
+        }
+
+        if method_type == "GET":
+            headers["Accept"] = "application/xml"
+        else:
+            headers["Content-Type"] = "application/xml"
+
+        return headers
+
+    def _build_authorization(self, method_type: str, path: str) -> tuple[str, str]:
+        now = datetime.now().strftime("%a, %d %b %Y %H:%M:%S GMT")
+        message = "\n".join([now, method_type, path])
+        digest = hmac.new(
+            self.account_key.encode("utf-8"),
+            msg=message.encode("utf-8"),
+            digestmod=hashlib.sha256
+        ).digest()
+        signature = base64.standard_b64decode(digest).decode()
+
+        return now, f"3MCLAUTH {self.account_id}:{signature}"
+
+
+class CloudLibraryClientError(Exception):
+    def __init__(self, message=None):
+        self.message = message

--- a/tests/test_cloudlibrary_client.py
+++ b/tests/test_cloudlibrary_client.py
@@ -1,37 +1,102 @@
-from unittest import mock
 import pytest
 
-from nypl_py_utils.classes.cloudlibrary_client import CloudLibraryClient
+from freezegun import freeze_time
+from unittest import mock
 
-_TEST_LIBRARY_EVENTS_RESPONSE = """<LibraryEventBatch xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/20
-01/XMLSchema-instance">
-<PublishId>4302fcca-ef99-49bf-bd29-d673e990f765</PublishId>
-<PublishDateTimeInUTC>2012-06-29T17:35:18</PublishDateTimeInUTC>
-<LastEventDateTimeInUTC>2012-06-26T13:58:52.055</LastEventDateTimeInUTC>
-<Events>
-<CloudLibraryEvent>
-<EventId>4302fcca-ef99-49bf-bd29-d673e990f4a7</EventId>
-<EventType>CHECKIN</EventType>
-<EventStartDateTimeInUTC>2012-06-26T05:07:56</EventStartDateTimeInUTC>
-<EventEndDateTimeInUTC>2012-06-26T07:50:59</EventEndDateTimeInUTC>
-<ItemId>edbz9</ItemId>
-<ItemLibraryId>1234</ItemLibraryId>
-<ISBN>9780307238405</ISBN>
-<PatronId>TestUser1</PatronId>
-<PatronLibraryId>1234</PatronLibraryId>
-<EventPublishDateTimeInUTC>2012-06-29T17:35:18</EventPublishDateTimeInUTC>
-</CloudLibraryEvent>
-</Events>
+from requests import ConnectTimeout
+from nypl_py_utils.classes.cloudlibrary_client import CloudLibraryClient, CloudLibraryClientError
+
+_API_URL = "https://partner.yourcloudlibrary.com/cirrus/library/"
+
+# catch-all API response since we're not testing actual data
+_TEST_LIBRARY_EVENTS_RESPONSE = """<LibraryEventBatch
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<PublishId>4302fcca-ef99-49bf-bd29-d673e990f765</PublishId>
+	<PublishDateTimeInUTC>2024-11-10T17:35:18</PublishDateTimeInUTC>
+	<LastEventDateTimeInUTC>2012-11-11T13:58:52.055</LastEventDateTimeInUTC>
+	<Events>
+		<CloudLibraryEvent>
+			<EventId>4302fcca-ef99-49bf-bd29-d673e990f4a7</EventId>
+			<EventType>CHECKIN</EventType>
+			<EventStartDateTimeInUTC>2024-11-10T05:07:56</EventStartDateTimeInUTC>
+			<EventEndDateTimeInUTC>2024-11-10T07:50:59</EventEndDateTimeInUTC>
+			<ItemId>edbz9</ItemId>
+			<ItemLibraryId>1234</ItemLibraryId>
+			<ISBN>9780307238405</ISBN>
+			<PatronId>TestUser1</PatronId>
+			<PatronLibraryId>1234</PatronLibraryId>
+			<EventPublishDateTimeInUTC>2024-11-10T17:35:18</EventPublishDateTimeInUTC>
+		</CloudLibraryEvent>
+	</Events>
 </LibraryEventBatch>
 """
 
 
+@freeze_time("2024-11-11 10:00:00")
 class TestCloudLibraryClient:
     @pytest.fixture
     def test_instance(self):
-        client = CloudLibraryClient("library_id", "account_id", "account_key")
-        client.request = mock.MagicMock()
-        return client
+        return CloudLibraryClient(
+            "library_id", "account_id", "account_key")
 
-    def test_get_library_events_success(self, test_instance):
-        return
+    def test_get_library_events_success_no_args(self, test_instance, requests_mock, caplog):
+        start = "2024-11-10T10:00:00"
+        end = "2024-11-11T10:00:00"
+        requests_mock.get(
+            f"{_API_URL}{test_instance.library_id}/data/cloudevents?startdate={start}&enddate={end}",
+            text=_TEST_LIBRARY_EVENTS_RESPONSE)
+        response = test_instance.get_library_events()
+
+        assert response.text == _TEST_LIBRARY_EVENTS_RESPONSE
+        assert f"Fetching all library events in time frame {start} to {end}..." in caplog.text
+
+    def test_get_library_events_success_with_start_and_end_date(self, test_instance, requests_mock, caplog):
+        start = "2024-11-01T10:00:00"
+        end = "2024-11-05T10:00:00"
+        requests_mock.get(
+            f"{_API_URL}{test_instance.library_id}/data/cloudevents?startdate={start}&enddate={end}",
+            text=_TEST_LIBRARY_EVENTS_RESPONSE)
+        response = test_instance.get_library_events(start, end)
+
+        assert response.text == _TEST_LIBRARY_EVENTS_RESPONSE
+        assert f"Fetching all library events in time frame {start} to {end}..." in caplog.text
+
+    def test_get_library_events_success_with_no_end_date(self, test_instance, requests_mock, caplog):
+        start = "2024-11-01T09:00:00"
+        end = "2024-11-11T10:00:00"
+        requests_mock.get(
+            f"{_API_URL}{test_instance.library_id}/data/cloudevents?startdate={start}&enddate={end}",
+            text=_TEST_LIBRARY_EVENTS_RESPONSE)
+        response = test_instance.get_library_events(start)
+
+        assert response.text == _TEST_LIBRARY_EVENTS_RESPONSE
+        assert f"Fetching all library events in time frame {start} to {end}..." in caplog.text
+
+    def test_get_library_events_exception_when_start_date_greater_than_end(self, test_instance, caplog):
+        start = "2024-11-11T09:00:00"
+        end = "2024-11-01T10:00:00"
+
+        with pytest.raises(CloudLibraryClientError):
+            test_instance.get_library_events(start, end)
+        assert f"Start date {start} is greater than end date {end}, cannot retrieve library events" in caplog.text
+
+    def test_get_library_events_failure(self, test_instance, requests_mock):
+        start = "2024-11-10T10:00:00"
+        end = "2024-11-11T10:00:00"
+        requests_mock.get(
+            f"{_API_URL}{test_instance.library_id}/data/cloudevents?startdate={start}&enddate={end}",
+            exc=ConnectTimeout)
+
+        with pytest.raises(CloudLibraryClientError):
+            test_instance.get_library_events()
+
+    def test_create_request_body_success(self, test_instance):
+        request_type = "CheckoutRequest"
+        item_id = "df45qw"
+        patron_id = "215555602845"
+        EXPECTED_REQUEST_BODY = f"<{request_type}><ItemId>{item_id}</ItemId><PatronId>{patron_id}</PatronId></{request_type}>"
+        request_body = test_instance.create_request_body(
+            request_type, item_id, patron_id)
+
+        assert request_body == EXPECTED_REQUEST_BODY

--- a/tests/test_cloudlibrary_client.py
+++ b/tests/test_cloudlibrary_client.py
@@ -1,0 +1,37 @@
+from unittest import mock
+import pytest
+
+from nypl_py_utils.classes.cloudlibrary_client import CloudLibraryClient
+
+_TEST_LIBRARY_EVENTS_RESPONSE = """<LibraryEventBatch xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/20
+01/XMLSchema-instance">
+<PublishId>4302fcca-ef99-49bf-bd29-d673e990f765</PublishId>
+<PublishDateTimeInUTC>2012-06-29T17:35:18</PublishDateTimeInUTC>
+<LastEventDateTimeInUTC>2012-06-26T13:58:52.055</LastEventDateTimeInUTC>
+<Events>
+<CloudLibraryEvent>
+<EventId>4302fcca-ef99-49bf-bd29-d673e990f4a7</EventId>
+<EventType>CHECKIN</EventType>
+<EventStartDateTimeInUTC>2012-06-26T05:07:56</EventStartDateTimeInUTC>
+<EventEndDateTimeInUTC>2012-06-26T07:50:59</EventEndDateTimeInUTC>
+<ItemId>edbz9</ItemId>
+<ItemLibraryId>1234</ItemLibraryId>
+<ISBN>9780307238405</ISBN>
+<PatronId>TestUser1</PatronId>
+<PatronLibraryId>1234</PatronLibraryId>
+<EventPublishDateTimeInUTC>2012-06-29T17:35:18</EventPublishDateTimeInUTC>
+</CloudLibraryEvent>
+</Events>
+</LibraryEventBatch>
+"""
+
+
+class TestCloudLibraryClient:
+    @pytest.fixture
+    def test_instance(self):
+        client = CloudLibraryClient("library_id", "account_id", "account_key")
+        client.request = mock.MagicMock()
+        return client
+
+    def test_get_library_events_success(self, test_instance):
+        return


### PR DESCRIPTION
Since this client is used within eReading and PJR, thought it would be useful to add here! 

This cloudLibrary client is relatively straightforward -- the only weird thing is the `request` function, which is necessary for formatting headers and authorization for each API call. This `request` function is modeled after a [similar one used in eReading](https://github.com/NYPL-Simplified/circulation/blob/e04a676419be87c7d9ac1967a6b637904fa729e4/api/bibliotheca.py#L241). Wasn't entirely sure whether it's worth testing since all it's doing is an API call, but lmk your thoughts!