### PR TITLE
Use fastavro for avro encoding/decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## v1.6.5 6/13/25
+## v1.7.0 6/13/25
 - Use fastavro for avro encoding/decoding
 
 ## v1.6.5 3/24/25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.6.5 6/13/25
+- Use fastavro for avro encoding/decoding
+
 ## v1.6.5 3/24/25
 - Add capability to return PostgreSQL cursor description
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nypl_py_utils"
-version = "1.6.6"
+version = "1.7.0"
 authors = [
   { name="Aaron Friedman", email="aaronfriedman@nypl.org" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ development = [
     "flake8>=6.0.0",
     "freezegun>=1.2.2",
     "mock>=4.0.3",
-    "pytest>=7.2.0",
+    "pytest==8.0",
     "pytest-mock>=3.10.0",
     "requests-mock>=1.10.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nypl_py_utils"
-version = "1.6.5"
+version = "1.6.6"
 authors = [
   { name="Aaron Friedman", email="aaronfriedman@nypl.org" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = []
 
 [project.optional-dependencies]
 avro-client = [
-    "avro>=1.11.1",
+    "fastavro>=1.11.1",
     "requests>=2.28.1"
 ]
 cloudlibrary-client = [

--- a/src/nypl_py_utils/classes/avro_client.py
+++ b/src/nypl_py_utils/classes/avro_client.py
@@ -83,7 +83,8 @@ class AvroEncoder(AvroClient):
             )
         with BytesIO() as output_stream:
             try:
-                schemaless_writer(output_stream, self.schema, record, strict_allow_default=True)
+                schemaless_writer(output_stream, self.schema, record,
+                                  strict_allow_default=True)
                 return output_stream.getvalue()
             except Exception as e:
                 self.logger.error("Failed to encode record: {}".format(e))
@@ -102,7 +103,8 @@ class AvroEncoder(AvroClient):
                 num_rec=len(record_list), schema=self.schema['name']
             )
         )
-        return [self.encode_record(record, silent=True) for record in record_list]
+        return [self.encode_record(record, silent=True)
+                for record in record_list]
 
 
 class AvroDecoder(AvroClient):
@@ -132,7 +134,6 @@ class AvroDecoder(AvroClient):
                 raise AvroClientError(
                     "Failed to decode record: {}".format(e)) from None
 
-
     def decode_batch(self, record_list):
         """
         Decodes a list of JSON records using the given Avro schema. Input
@@ -145,7 +146,8 @@ class AvroDecoder(AvroClient):
                 num_rec=len(record_list), schema=self.schema['name']
             )
         )
-        return [self.decode_record(record, silent=True) for record in record_list]
+        return [self.decode_record(record, silent=True)
+                for record in record_list]
 
 
 class AvroClientError(Exception):

--- a/tests/test_avro_client.py
+++ b/tests/test_avro_client.py
@@ -20,6 +20,43 @@ _TEST_SCHEMA = {'data': {'schema': json.dumps({
     ]
 })}}
 
+FASTAVRO_SCHEMA = {
+  "type": "record",
+  "name": "TestSchema",
+  "fields": [
+    {
+      "name": "patron_id",
+      "type": "int"
+    },
+    {
+      "name": "library_branch",
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  ],
+  "__fastavro_parsed": True,
+  "__named_schemas": {
+    "TestSchema": {
+      "type": "record",
+      "name": "TestSchema",
+      "fields": [
+        {
+          "name": "patron_id",
+          "type": "int"
+        },
+        {
+          "name": "library_branch",
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      ]
+    }
+  }
+}
 
 class TestAvroClient:
     @pytest.fixture
@@ -36,10 +73,7 @@ class TestAvroClient:
 
     def test_get_json_schema_success(self, test_avro_encoder_instance,
                                      test_avro_decoder_instance):
-        assert test_avro_encoder_instance.schema == _TEST_SCHEMA["data"][
-            "schema"]
-        assert test_avro_decoder_instance.schema == _TEST_SCHEMA["data"][
-            "schema"]
+        assert test_avro_encoder_instance.schema == FASTAVRO_SCHEMA
 
     def test_get_json_schema_error(self, requests_mock):
         requests_mock.get("https://test_schema_url", exc=ConnectTimeout)

--- a/tests/test_avro_client.py
+++ b/tests/test_avro_client.py
@@ -58,6 +58,7 @@ FASTAVRO_SCHEMA = {
   }
 }
 
+
 class TestAvroClient:
     @pytest.fixture
     def test_avro_encoder_instance(self, requests_mock):


### PR DESCRIPTION
* [LSP tracking ticket](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4748)
* We ran into an issue in our BibServiceV2 implementation where we saw extreme latency during avro encoding of records. See [this issue](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4728) for context. Switching to `fastavro` shows considerable improvements over `avro` in our benchmarks. The following benchmark is comparing the current avro_encoder in nypl-python-utils with the one in this PR:

```
-- Python (avro) ------------------------------
2025-06-13 12:05:59,742 | avro_encoder | INFO: Fetching Avro schema from https://platform.nypl.org/api/v0.1/current-schemas/Bib
Encoding sample-bib.json 100 times
2025-06-13 12:06:00,168 | avro_encoder | INFO: Encoding (100) records using Bib schema
Encoded 100 records

real	0m4.427s
user	0m3.952s
sys	0m0.052s
--
-- Python (fastavro) ------------------------------
2025-06-13 12:06:04,153 | avro_client | INFO: Fetching Avro schema from https://platform.nypl.org/api/v0.1/current-schemas/Bib
Encoding sample-bib.json 100 times
2025-06-13 12:06:04,399 | avro_client | INFO: Encoding (100) records using Bib schema
Encoded 100 records

real	0m0.747s
user	0m0.478s
sys	0m0.022s
--
```

* I'm making this change with the intent of being fully backward compatible with existing services using this client. See the passing unit tests which are unchanged apart from the new fastavro-aware schema, which won't be exposed to any users of the module. Let me know if you have any concerns in that regard.
* You'll notice that I'm using `schemaless_writer` and `schemaless_reader` in this change. In my testing, using the standard fastavro `writer` and `reader` put headers onto the encoded data which didn't match the bytes of the unit test's expected data. In order to adhere to the existing tests (and presumably existing encoders/decoders) I opted to exclude the headers during encoding.
* Note: it looks like several unit tests in this package for unrelated modules were broken before I made this change (KinesisClient, CloudLibraryClient). Just calling that out lest it appear that these changes introduced test failures