### PR TITLE
add timeout flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.10.1 4/14/26
+- Add optional timeout param for OAuth2Client
+
 ## v1.10.0 3/17/26
 - Add Snowflake client
 - Update config helper to allow loading config files without PLAINTEXT/ENCRYPTED structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nypl_py_utils"
-version = "1.10.0"
+version = "1.10.1"
 authors = [
   { name="Aaron Friedman", email="aaronfriedman@nypl.org" },
 ]

--- a/src/nypl_py_utils/classes/oauth2_api_client.py
+++ b/src/nypl_py_utils/classes/oauth2_api_client.py
@@ -16,7 +16,8 @@ class Oauth2ApiClient:
     """
 
     def __init__(self, client_id=None, client_secret=None, base_url=None,
-                 token_url=None, with_retries=False):
+                 token_url=None, with_retries=False, timeoutInSeconds=None):
+        self.timeoutInSeconds = timeoutInSeconds
         self.client_id = client_id \
             or os.environ.get('NYPL_API_CLIENT_ID', None)
         self.client_secret = client_secret \
@@ -140,6 +141,7 @@ Oauth2 Client using path: {request_path}. Retry #{retries}')
         """
         self.logger.debug(f'Refreshing token via @{self.token_url}')
         self.oauth_client.fetch_token(
+            timeout=self.timeoutInSeconds,
             token_url=self.token_url,
             client_id=self.client_id,
             client_secret=self.client_secret

--- a/src/nypl_py_utils/classes/oauth2_api_client.py
+++ b/src/nypl_py_utils/classes/oauth2_api_client.py
@@ -16,8 +16,8 @@ class Oauth2ApiClient:
     """
 
     def __init__(self, client_id=None, client_secret=None, base_url=None,
-                 token_url=None, with_retries=False, timeoutInSeconds=None):
-        self.timeoutInSeconds = timeoutInSeconds
+                 token_url=None, with_retries=False, timeout_in_seconds=None):
+        self.timeout_in_seconds = timeout_in_seconds
         self.client_id = client_id \
             or os.environ.get('NYPL_API_CLIENT_ID', None)
         self.client_secret = client_secret \
@@ -141,7 +141,7 @@ Oauth2 Client using path: {request_path}. Retry #{retries}')
         """
         self.logger.debug(f'Refreshing token via @{self.token_url}')
         self.oauth_client.fetch_token(
-            timeout=self.timeoutInSeconds,
+            timeout=self.timeout_in_seconds,
             token_url=self.token_url,
             client_id=self.client_id,
             client_secret=self.client_secret


### PR DESCRIPTION
Sierra token requests are taking a very long time, and causing our lambdas to timeout. Adding a timeout param so the requests fail before the lambda spins down.