### PR TITLE
Reset Snowflake connection to None when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.11.1 5/20/26
+- Reset Snowflake connection to None when it's closed
+
 ## v1.11.0 4/27/26
 - Allow Snowflake client to connect using any parameters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nypl_py_utils"
-version = "1.11.0"
+version = "1.11.1"
 authors = [
   { name="Aaron Friedman", email="aaronfriedman@nypl.org" },
 ]

--- a/src/nypl_py_utils/classes/s3_client.py
+++ b/src/nypl_py_utils/classes/s3_client.py
@@ -58,7 +58,7 @@ class S3Client:
         except ClientError as e:
             error_msg = (
                 f'Error uploading {self.resource} to S3 bucket '
-                f'{self.s3_bucket}: {e}')
+                f'{self.bucket}: {e}')
             self.logger.error(error_msg)
             raise S3ClientError(error_msg) from None
 
@@ -83,7 +83,7 @@ class S3Client:
         except ClientError as e:
             error_msg = (
                 f'Error uploading {file_path} to S3 bucket '
-                f'{self.s3_bucket}: {e}')
+                f'{self.bucket}: {e}')
             self.logger.error(error_msg)
             raise S3ClientError(error_msg) from None
 

--- a/src/nypl_py_utils/classes/snowflake_client.py
+++ b/src/nypl_py_utils/classes/snowflake_client.py
@@ -87,6 +87,7 @@ class SnowflakeClient:
         """Closes the connection"""
         self.logger.info('Closing Snowflake connection')
         self.conn.close()
+        self.conn = None
 
 
 class SnowflakeClientError(Exception):

--- a/tests/test_snowflake_client.py
+++ b/tests/test_snowflake_client.py
@@ -38,18 +38,27 @@ class TestSnowflakeClient:
     def test_execute_query_with_exception(
             self, mock_snowflake_conn, test_instance, mocker):
         test_instance.connect()
+        test_conn = test_instance.conn
 
         mock_cursor = mocker.MagicMock()
         mock_cursor.execute.side_effect = Exception()
-        test_instance.conn.cursor.return_value = mock_cursor
+        test_conn.cursor.return_value = mock_cursor
 
         with pytest.raises(SnowflakeClientError):
             test_instance.execute_query('test query')
 
         mock_cursor.close.assert_called()
-        test_instance.conn.close.assert_called_once()
+        test_conn.close.assert_called_once()
 
-    def test_close_connection(self, mock_snowflake_conn, test_instance):
+    def test_close_connection(self, mock_snowflake_conn, test_instance, mocker):
+        assert test_instance.conn is None
+
         test_instance.connect()
+
+        test_conn = test_instance.conn
+        assert test_conn is not None
+
         test_instance.close_connection()
-        test_instance.conn.close.assert_called_once()
+
+        test_conn.close.assert_called_once()
+        assert test_instance.conn is None

--- a/tests/test_snowflake_client.py
+++ b/tests/test_snowflake_client.py
@@ -50,7 +50,8 @@ class TestSnowflakeClient:
         mock_cursor.close.assert_called()
         test_conn.close.assert_called_once()
 
-    def test_close_connection(self, mock_snowflake_conn, test_instance, mocker):
+    def test_close_connection(
+            self, mock_snowflake_conn, test_instance, mocker):
         assert test_instance.conn is None
 
         test_instance.connect()


### PR DESCRIPTION
This will allow users of the client to easily be able to tell whether a connection is currently open