### PR TITLE
Remove encoding/decoding from AzureClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.12.1 6/18/26
+- Remove Azure client encoding and decoding
+
 ## v1.12.0 6/15/26
 - Add Azure client
 

--- a/src/nypl_py_utils/classes/azure_client.py
+++ b/src/nypl_py_utils/classes/azure_client.py
@@ -50,10 +50,6 @@ class AzureClient:
                         connection_str=connection_string,
                         timeout=30,
                     )
-                    self.conn.setencoding(encoding="utf-8")
-                    self.conn.setdecoding(
-                        sqltype=mssql_python.SQL_WCHAR, encoding="utf-8"
-                    )
                     return
                 except (mssql_python.InterfaceError,
                         mssql_python.OperationalError):

--- a/tests/test_azure_client.py
+++ b/tests/test_azure_client.py
@@ -25,12 +25,6 @@ class TestAzureClient:
         test_instance.connect()
 
         assert test_instance.conn == mock_azure_conn.return_value
-        mock_azure_conn.return_value.setencoding.assert_called_once_with(
-            encoding="utf-8"
-        )
-        mock_azure_conn.return_value.setdecoding.assert_called_once_with(
-            sqltype=mssql_python.SQL_WCHAR, encoding="utf-8"
-        )
         # credentials are interpolated into connection string
         connection_str = mock_azure_conn.call_args.kwargs["connection_str"]
         assert connection_str == (


### PR DESCRIPTION
Encoding/decoding in the [newest mssql-python release](https://pypi.org/project/mssql-python/1.9.0/) causes the following error:

> Driver Error: UTF-16 with Byte Order Mark not supported for SQL_WCHAR; DDBC Error: Cannot use 'utf-16' encoding with SQL_WCHAR due to Byte Order Mark ambiguity. Use 'utf-16le' or 'utf-16be' instead for explicit byte order

yay :D